### PR TITLE
Fixed name of signup_success class

### DIFF
--- a/classes/event/signup_success.php
+++ b/classes/event/signup_success.php
@@ -38,7 +38,7 @@ defined('MOODLE_INTERNAL') || die();
  * @author     Stacey Walker <stacey@catalyst-eu.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class signup extends \core\event\base {
+class signup_success extends \core\event\base {
 
     /**
      * Init method.


### PR DESCRIPTION
There's currently a bug which causes an error when signing up. The class signup_success is referred to in the code and a class file exists called signup_success but the class within it is signup.